### PR TITLE
Include the license file in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
It is very important to include the LICENSE file for legal reasons.